### PR TITLE
use name instead username on admin creation to working with the latest version for influxdb

### DIFF
--- a/providers/admin.rb
+++ b/providers/admin.rb
@@ -33,7 +33,7 @@ action :create do
     Chef::Log.fatal!('You must provide a password for the :create' \
                      ' action on this resource!')
   end
-  unless @client.get_cluster_admin_list.collect {|x| x['username']}.member?(@username)
+  unless @client.get_cluster_admin_list.collect {|x| x['name']}.member?(@username)
     @client.create_cluster_admin(@username, @password)
   end
 end


### PR DESCRIPTION
The latest version on influxdb uses "name" instead "username" to work with cluster_admin.

influxdb/influxdb#443

Thus, we just change one line on the action to create admin, when checks if the admin already exists.
