### PR TITLE
Adding database admin support in influxdb_user resource

### DIFF
--- a/resources/user.rb
+++ b/resources/user.rb
@@ -24,4 +24,5 @@ default_action(:create)
 
 attribute(:username, kind_of: String, name_attribute: true)
 attribute(:password, kind_of: String)
-attribute(:databases, kind_of: Array, required: true)
+attribute(:databases, kind_of: Array, required: false, default: [])
+attribute(:dbadmin, kind_of: Array, required: false, default: [])


### PR DESCRIPTION
## Adding db admin feature

ref issue #31 :

Adding a new `dbadmin` attribute in `influxdb_user`.
- This attribute is optional (default is empty)
- It takes an array of database name
- it creates specified user into db and gives him admin rights on all the db listed in `dbadmin`
- it can be used with current `databases` attribute.
- `databases` attribute is now optional (default is empty) : if no databases are specified either in db or dbadmin, the user will not be created (it's not an error)
## Example

**Recipe :**

```
influxdb_user 'nothing' do
  password 'nothing'
end

influxdb_user 'user' do
  password 'user'
  databases ['metrics']
end

influxdb_user 'admin' do
  password 'admin'
  dbadmin ['metrics']
end

influxdb_user 'both' do
  password 'both'
  databases ['metrics']
  dbadmin ['metrics']
end
```

**Log**

```
  * influxdb_user[nothing] action create
  Recipe: <Dynamically Defined Resource>
    * chef_gem[influxdb] action install (up to date)
     (up to date)

  * influxdb_user[user] action create
  Recipe: <Dynamically Defined Resource>
    * chef_gem[influxdb] action install (up to date)
     (up to date)

  * influxdb_user[admin] action create
  Recipe: <Dynamically Defined Resource>
    * chef_gem[influxdb] action install (up to date)
     (up to date)

  * influxdb_user[both] action create
  Recipe: <Dynamically Defined Resource>
    * chef_gem[influxdb] action install (up to date)
     (up to date)
```

**Result**
![selection_010](https://cloud.githubusercontent.com/assets/1901955/4578488/35d85e52-4fc5-11e4-8ca8-565c175e89cb.png)
