### PR TITLE
Update default checksum attributes of recent influxdb releases

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,12 +26,14 @@ default[:influxdb][:versions] = {
   amd64: {
     '0.3.0' => 'a6801a18a45793ad1afa121f023f21368b06216d433cfa2381f7288385f93af6',
     '0.4.3' => 'd2d1c69d8e888cbf0ec6f3a6a72a47dbc1d177c83151f95a7e51769616ec5431',
-    :latest => 'd2d1c69d8e888cbf0ec6f3a6a72a47dbc1d177c83151f95a7e51769616ec5431'
+    '0.8.3' => 'c55b672cec4e745e8cbbd458dbac13824ca73ce42fac762ffe441809ebe9dab0',
+    :latest => 'c55b672cec4e745e8cbbd458dbac13824ca73ce42fac762ffe441809ebe9dab0'
   },
   i386: {
     '0.3.0' => '1182b656a0c6e1ab8a28a2dcda0adab707df43258ba76e4ec5e05d61695b40ff',
     '0.4.3' => 'ae468726d096f7acf62fd96794356b1c2fa4d81789d67c48ed44f87add7bc0ea',
-    :latest => 'ae468726d096f7acf62fd96794356b1c2fa4d81789d67c48ed44f87add7bc0ea'
+    '0.8.3' => '3110ba7e23e7660ca5dbfd133b492bf2aaad5a7743ffa4a22c44a115b37ef720',
+    :latest => '3110ba7e23e7660ca5dbfd133b492bf2aaad5a7743ffa4a22c44a115b37ef720'
   }
 }
 


### PR DESCRIPTION
Hi folks,

Is there a reason to not keep updated checksums of recent releases?
This would avoid the unnecessary download of packages due to mismatched checksums every time chef-client run, isn't?

Thanks for maintaining this cookbook.

Cheers,
