### PR TITLE
Start influxdb instance in default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,5 +27,5 @@ influxdb 'main' do
   source node[:influxdb][:source]
   checksum node[:influxdb][:versions][arch][ver]
   config node[:influxdb][:config]
-  action [:create]
+  action [:create, :start]
 end


### PR DESCRIPTION
Otherwise calls to influxdb_* LWRPs will fail because influxdb isn't running yet.