### PR TITLE
Lazily load attrs for influxdb_config

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,7 +62,7 @@ package 'influxdb' do
 end
 
 influxdb_config node['influxdb']['config_file_path'] do
-  config node['influxdb']['config']
+  config lazy { node['influxdb']['config'] }
 end
 
 service 'influxdb' do


### PR DESCRIPTION
As it stands, in-recipe (and I believe even wrapper-cookbook attribute/ folder) attribute changes cannot affect the config written to disk