### PR TITLE
Update for Influxdb 0.10

### DIFF
--- a/.kitchen-docker.yml
+++ b/.kitchen-docker.yml
@@ -9,7 +9,7 @@ provisioner:
   name: chef_zero
 
 platforms:
-<% %w(12.5 12.4.3 12.3 12.2 12.1).each do |chef_version| %>
+<% %w(12.7 12.6 12.5 12.4.3 12.3 12.2 12.1).each do |chef_version| %>
   - name: ubuntu-14.04-chef<%= chef_version %>
     driver_config:
       image: ubuntu:14.04
@@ -50,7 +50,10 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[influxdb::default]
       - recipe[influxdb-test::default]
       - recipe[netstat]
     attributes:
+  - name: config_change
+    run_list:
+      - recipe[influxdb-test::default]
+      - recipe[influxdb-test::config_change]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,7 +6,7 @@ provisioner:
   name: chef_zero
 
 platforms:
-<% %w(12.5 12.4 12.3 12.2 12.1).each do |chef_version| %>
+<% %w(12.7 12.6 12.5 12.4 12.3 12.2 12.1).each do |chef_version| %>
   - name: ubuntu-14.04-chef<%= chef_version %>
     driver:
       box: bento/ubuntu-14.04
@@ -37,6 +37,9 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[influxdb::default]
       - recipe[influxdb-test::default]
     attributes:
+  - name: config_change
+    run_list:
+      - recipe[influxdb-test::default]
+      - recipe[influxdb-test::config_change]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 Metrics/LineLength:
   Enabled: false
 
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,11 @@ source 'https://supermarket.chef.io'
 
 metadata
 
+# FIXME: keep to this branch until
+#        https://github.com/chef-cookbooks/compat_resource/issues/37 is resolved
+cookbook 'compat_resource', git: 'git://github.com/b-dean/compat_resource.git',
+                            branch: 'require_resource_builder'
+
 group :test do
   cookbook 'influxdb-test', path: 'test/fixtures/cookbooks/influxdb-test'
   cookbook 'netstat'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [unreleased]
 
+## 4.1.0
+* Updated attributes to support Influxdb 0.10.0
+* Set default resource actions (:create is default)
+* Fixed support for Chef-Client 12.6
+* Fixed rubocop styling
+* Added functional test to check restarts service restarts on config change
+
 ## 4.0.1
 * License update from Apache 2.0 to MIT
   - transfer of ownership

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,33 +21,55 @@ default['influxdb']['ssl_cert_file_path'] = '/etc/ssl/influxdb.pem'
 default['influxdb']['config_file_path'] = '/etc/influxdb/influxdb.conf'
 
 # For influxdb versions >= 0.9.x
+# ref: https://docs.influxdata.com/influxdb/v0.10/administration/config/
 default['influxdb']['config'] = {
   'reporting-disabled' => false,
   'meta' => {
+    'enabled' => true,
     'dir' => node['influxdb']['meta_file_path'],
-    'hostname' => 'localhost',
     'bind-address' => ':8088',
     'retention-autocreate' => true,
     'election-timeout' => '1s',
     'heartbeat-timeout' => '1s',
     'leader-lease-timeout' => '500ms',
-    'commit-timeout' => '50ms'
+    'commit-timeout' => '50ms',
+    'cluster-tracing' => false
   },
   'data' => {
+    'enabled' => true,
     'dir' => node['influxdb']['data_file_path'],
+    'engine' => 'tsm1',
+    # applies only to 0.9.2
     'max-wal-size' => 104_857_600,
-    'wal-flush-interval' => '10m',
+    'wal-flush-interval' => '10m0s',
     'wal-partition-flush-delay' => '2s',
+    # applies only to >= 0.9.3
     'wal-dir' => node['influxdb']['wal_file_path'],
-    'wal-enable-logging' => true
+    'wal-enable-logging' => true,
+    'data-logging-enabled' => true
+  },
+  'hinted-handoff' => {
+    'enabled' => true,
+    'dir' => node['influxdb']['hinted-handoff_file_path'],
+    'max-size' => 1_073_741_824,
+    'max-age' => '168h0m0s',
+    'retry-rate-limit' => 0,
+    'retry-interval' => '1s',
+    'retry-max-interval' => '1m0s',
+    'purge-interval' => '1h0m0s'
   },
   'cluster' => {
-    'shard-writer-timeout' => '5s',
-    'write-timeout' => '5s'
+    'write-timeout' => '10s',
+    'shard-writer-timeout' => '5s'
   },
   'retention' => {
     'enabled' => true,
-    'check-interval' => '30m'
+    'check-interval' => '30m0s'
+  },
+  'shard-precreation' => {
+    'enabled' => true,
+    'check-interval' => '10m0s',
+    'advance-period' => '30m0s'
   },
   'monitor' => {
     'store-enabled' => true,
@@ -89,29 +111,21 @@ default['influxdb']['config'] = {
   'continuous_queries' => {
     'log-enabled' => true,
     'enabled' => true,
-    'recompute-previous-n' => 2,
-    'recompute-no-older-than' => '10m',
-    'compute-runs-per-interval' => 10,
-    'compute-no-more-than' => '2m'
+    'run-interval' => '1s'
   },
-  'hinted-handoff' => {
-    'enabled' => true,
-    'dir' => node['influxdb']['hinted-handoff_file_path'],
-    'max-size' => 1_073_741_824,
-    'max-age' => '168h',
-    'retry-rate-limit' => 0,
-    'retry-interval' => '1s'
+  'subscriber' => {
+    'enabled' => true
   }
 }
 
 case node['platform_family']
 when 'rhel', 'fedora'
-  case node['platform']
-  when 'centos'
-    default['influxdb']['upstream_repository'] = "https://repos.influxdata.com/centos/#{node['platform_version'].to_i}/$basearch/stable"
-  else
-    default['influxdb']['upstream_repository'] = "https://repos.influxdata.com/rhel/#{node['platform_version'].to_i}/$basearch/stable"
-  end
+  default['influxdb']['upstream_repository'] = case node['platform']
+                                               when 'centos'
+                                                 "https://repos.influxdata.com/centos/#{node['platform_version'].to_i}/$basearch/stable"
+                                               else
+                                                 "https://repos.influxdata.com/rhel/#{node['platform_version'].to_i}/$basearch/stable"
+                                               end
 else
   default['influxdb']['upstream_repository'] = "https://repos.influxdata.com/#{node['platform']}"
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Ben Dang'
 maintainer_email 'me@bdang.it'
 license          'MIT'
 description      'InfluxDB, a timeseries database'
-version          '4.0.1'
+version          '4.1.0'
 
 # For CLI client
 # https://github.com/redguide/nodejs

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -7,6 +7,8 @@ property :password, String
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
 
+default_action :create
+
 action :create do
   unless password
     Chef::Log.fatal('You must provide a password for the :create action on this resource!')

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -5,6 +5,8 @@
 property :path, String, name_property: true
 property :config, Hash, required: true
 
+default_action :create
+
 action :create do
   require 'toml'
 

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -6,6 +6,8 @@ property :name, String, name_property: true
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
 
+default_action :create
+
 action :create do
   next if client.list_databases.map { |x| x['name'] }.member?(name)
 

--- a/resources/retention_policy.rb
+++ b/resources/retention_policy.rb
@@ -11,6 +11,8 @@ property :default, [TrueClass, FalseClass], default: false
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
 
+default_action :create
+
 action :create do
   if current_policy
     if current_policy['duration'] != duration || current_policy['replicaN'] != replication || current_policy['default'] != default

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -9,6 +9,8 @@ property :permissions, Array, default: []
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
 
+default_action :create
+
 action :create do
   unless password
     Chef::Log.fatal('You must provide a password for the :create action on this resource')

--- a/test/fixtures/cookbooks/influxdb-test/recipes/config_change.rb
+++ b/test/fixtures/cookbooks/influxdb-test/recipes/config_change.rb
@@ -1,0 +1,13 @@
+node.default['influxdb']['config']['graphite'] = [
+  {
+    'enabled' => true
+  }
+]
+influxdb_config node['influxdb']['config_file_path'] do
+  config node['influxdb']['config']
+  notifies :restart, 'service[influxdb]'
+end
+
+service 'influxdb' do
+  action :nothing
+end

--- a/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
@@ -1,3 +1,5 @@
+include_recipe 'influxdb::default'
+
 # Create a test database
 influxdb_database 'test_database' do
   action :create

--- a/test/integration/config_change/serverspec/default_spec.rb
+++ b/test/integration/config_change/serverspec/default_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'influxdb' do
+  describe user('influxdb') do
+    it { is_expected.to exist }
+  end
+
+  describe service('influxdb') do
+    it { is_expected.to be_running }
+  end
+
+  describe port(8083) do
+    it { is_expected.to be_listening }
+  end
+
+  describe port(8086) do
+    it { is_expected.to be_listening }
+  end
+
+  describe 'graphite' do
+    describe port(2003) do
+      it { is_expected.to be_listening }
+    end
+  end
+end

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,6 +8,7 @@ build:
     - script:
         name: lint style spec
         code: |
+          chef gem install rubocop --version 0.37.0
           chef exec "rake test:quick"
 deploy:
   steps:
@@ -23,5 +24,5 @@ deploy:
     - github-create-release:
         token: $GITHUB_TOKEN
         tag: $APP_VERSION
+        title: $APP_VERSION
     # TODO: setup stove to push to supermarket
-


### PR DESCRIPTION
* Updated attributes to support Influxdb 0.10.0
* Set default resource actions (:create is default)
* Fixed support for Chef-Client 12.6+
* Fixed rubocop styling
* Added functional test to check restarts service restarts on config change