### PR TITLE
Allow cookbook to install 1.0.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,7 +7,7 @@ provisioner:
   name: chef_zero
 
 platforms:
-<% %w(12.7 12.6 12.5 12.4.3 12.3 12.2 12.1).each do |chef_version| %>
+<% %w(12.14 12.7 12.1).each do |chef_version| %>
   - name: ubuntu-14.04-chef<%= chef_version %>
     driver_config:
       image: ubuntu:14.04
@@ -15,9 +15,9 @@ platforms:
       require_chef_omnibus: <%= chef_version %>
       provision_command:
           - apt-get install net-tools -y
-  - name: ubuntu-15.04-chef<%= chef_version %>
+  - name: ubuntu-15.10-chef<%= chef_version %>
     driver_config:
-      box: ubuntu:15.04
+      box: ubuntu:15.10
       platform: ubuntu
       run_command: /sbin/init
       privileged: true
@@ -25,9 +25,9 @@ platforms:
         - apt-get install net-tools -y
     provisioner:
       require_chef_omnibus: <%= chef_version %>
-  - name: debian-8.2-chef<%= chef_version %>
+  - name: debian-8.5-chef<%= chef_version %>
     driver_config:
-      box: debian:8.2
+      box: debian:8.5
       platform: debian
       run_command: /sbin/init
       privileged: true
@@ -36,18 +36,18 @@ platforms:
         - apt-get install net-tools -y
     provisioner:
       require_chef_omnibus: <%= chef_version %>
-  - name: centos-6.7-chef<%= chef_version %>
+  - name: centos-6.8-chef<%= chef_version %>
     driver_config:
-      box: centos:6.7
+      box: centos:6.8
       platform: centos
       provision_command:
        - yum install net-tools -y
        - yum install iproute -y
     provisioner:
       require_chef_omnibus: <%= chef_version %>
-  - name: centos-7.1-chef<%= chef_version %>
+  - name: centos-7.2-chef<%= chef_version %>
     driver_config:
-      box: centos:7.1
+      box: centos:7.2
       platform: centos
       run_command: /usr/sbin/init
       privileged: true
@@ -70,22 +70,11 @@ suites:
     attributes:
       influxdb:
         install_type: file
-        version: 0.10.3-1
+        version: 1.0.0
         shasums:
-          debian: 106e4884d8c654f1e43b803b21acc86e6494cafc50a46bcdb4330d0a51bd7aea
-          rhel: 8ba0bdb1abd9f6d16cd69a9b11062897061e0775e0691a986bb8dfd1bff58e5a
-
+          debian: 567005b50ab71ff7445f220093f008c9f42b9bce52a5e5568734e5fb5765b515
+          rhel: 5cb2b3699ef28cdb1ff7888aafcb1012d5c51b212ab216eea7a2436de658f8c7
   - name: config_change
     run_list:
       - recipe[influxdb-test::default]
       - recipe[influxdb-test::config_change]
-  - name: file
-    run_list:
-      - recipe[influxdb-test::default]
-    attributes:
-      influxdb:
-        install_type: file
-        version: 0.10.3-1
-        shasums:
-          debian: 106e4884d8c654f1e43b803b21acc86e6494cafc50a46bcdb4330d0a51bd7aea
-          rhel: 8ba0bdb1abd9f6d16cd69a9b11062897061e0775e0691a986bb8dfd1bff58e5a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.0.0
-  - 2.1.2
-bundler_args: --without development
-gemfile:
-  - Gemfile
-script: bundle exec rake test:quick

--- a/Berksfile
+++ b/Berksfile
@@ -2,11 +2,6 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-# FIXME: keep to this branch until
-#        https://github.com/chef-cookbooks/compat_resource/issues/37 is resolved
-cookbook 'compat_resource', git: 'git://github.com/b-dean/compat_resource.git',
-                            branch: 'require_resource_builder'
-
 group :test do
   cookbook 'influxdb-test', path: 'test/fixtures/cookbooks/influxdb-test'
   cookbook 'netstat'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [unreleased]
 
+## 5.0.0
+* [major] Support for 1.0.x which is **not backward compatible**
+* [major] Updated apt cookbook pin to ~> 4.0
+* [major] Updated yum cookbook pin to ~> 4.0
+* [minor] Reduce number of TK Cases to 12.1, 12.7 and 12.14.
+* [patch] removed specific branch used for `compat_resource`
+
 ## 4.4.1
 * Add steps to cut release
-* Fix invalid property type 'nil' in continuous query options (contributed by @kentarosasaki)
+* Fix invalid property type 'nil' in continuous query options (contributed by
+  @kentarosasaki)
 
 ## 4.4.0
 * Added support for file install type (contributed by @chrisduong)

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :integration do
   gem 'berkshelf'
-  gem 'kitchen-vagrant'
+  gem 'kitchen-docker'
   gem 'test-kitchen'
 end
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # InfluxDB
 
-[![wercker status](https://app.wercker.com/status/d0f175cb46e417cde7974f179e63084d/m "wercker status")](https://app.wercker.com/project/bykey/d0f175cb46e417cde7974f179e63084d)
+[![wercker status](https://app.wercker.com/status/d0f175cb46e417cde7974f179e63084d/s/master "wercker status")](https://app.wercker.com/project/byKey/d0f175cb46e417cde7974f179e63084d)
 
 Chef cookbook to install and configure InfluxDB.
+
+## Support
+
+|*Cookbook Version*|*InfluxDB Version*|
+|------------------|------------------|
+| v5.x.x           | >= v1.0.0        |
+| v4.4.1           | < v1.0.0         |
 
 ## Usage
 To install InfluxDB and place its configuration file, include the
@@ -49,7 +56,8 @@ end
 ```
 
 ### influxdb\_install
-This resource sets up or removes the appropriate repositories and installs/removes the appropriate packages
+This resource sets up or removes the appropriate repositories and
+installs/removes the appropriate packages
 
 ```ruby
 influxdb_install 'influxdb' do
@@ -91,6 +99,10 @@ end
 This resources configures a retention policy on a given database. The name
 attribute is not used, the database and policy name provide the unique names
 used by InfluxDB.
+
+> Note: in v1.0.0+ there is an auto-generated default profile called autogen.
+> To make your policy the default, you will want to set `default` parameter
+> `true`.
 
 ```ruby
 influxdb_retention_policy "foodb default retention policy" do

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Ben Dang'
 maintainer_email 'me@bdang.it'
 license          'MIT'
 description      'InfluxDB, a timeseries database'
-version          '4.4.1'
+version          '5.0.0'
 
 # For CLI client
 # https://github.com/redguide/nodejs
@@ -16,8 +16,8 @@ depends 'nodejs', '~> 2.4'
 depends 'chef_handler'
 
 # For apt and yum repositories
-depends 'apt', '~> 2.7'
-depends 'yum', '~> 3.6'
+depends 'apt', '~> 4.0'
+depends 'yum', '~> 4.0'
 
 # For compatibility with 12.X versions of Chef
 depends 'compat_resource'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -35,13 +35,13 @@ action :install do
         uri node['influxdb']['upstream_repository']
         distribution node['lsb']['codename']
         components ['stable']
-        arch_type new_resource.arch_type
+        arch new_resource.arch_type
         key influxdb_key
         only_if { include_repository }
       end
     else
       # NOTE: should raise to exit, instead of warn, since we failed to install InfluxDB
-      raise "I do not support your platform: #{node.platform_family}"
+      raise "I do not support your platform: #{node['platform_family']}"
     end
 
     package 'influxdb' do
@@ -74,7 +74,7 @@ action :install do
         action :install
       end
     else
-      raise "I do not support your platform: #{node.platform_family}"
+      raise "I do not support your platform: #{node['platform_family']}"
     end
   else
     raise "#{install_type} is not a valid install type."
@@ -89,11 +89,11 @@ action :remove do
     end
   elsif node.platform_family? 'debian'
     apt_repository 'influxdb' do
-      action :delete
+      action :remove
       only_if { include_repository }
     end
   else
-    Chef.Log.warn "I do not support your platform: #{node.platform_family}"
+    raise "I do not support your platform: #{node['platform_family']}"
   end
 
   package 'influxdb' do

--- a/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
@@ -1,14 +1,16 @@
 include_recipe 'influxdb::default'
 
+dbname = 'test_database'
+
 # Create a test database
-influxdb_database 'test_database' do
+influxdb_database dbname do
   action :create
 end
 
 # Create a test user and give it access to the test database
 influxdb_user 'test_user' do
   password 'test_password'
-  databases ['test_database']
+  databases [dbname]
   action :create
 end
 
@@ -21,15 +23,21 @@ end
 # Create a test retention policy on the test database
 influxdb_retention_policy 'test_policy' do
   policy_name 'default'
-  database 'test_database'
+  database dbname
   duration '1w'
   replication 1
+  # by default in v1.0 there's a policy named autogen that is created for any
+  # db, when `meta.retention-autocreate`=true. We will make this test_policy
+  # the default policy.
+  # ref1: https://docs.influxdata.com/influxdb/v1.0/query_language/database_management/#retention-policy-management
+  # ref2: https://docs.influxdata.com/influxdb/v1.0/administration/config/#meta
+  default true
   action :create
 end
 
 # Create a test continuous query on the test database
 influxdb_continuous_query 'test_cq' do
-  database 'test_database'
+  database dbname
   query 'SELECT min(mouse) INTO min_mouse FROM zoo GROUP BY time(30m)'
   action :create
 end

--- a/test/integration/file/serverspec/default_spec.rb
+++ b/test/integration/file/serverspec/default_spec.rb
@@ -9,7 +9,7 @@ describe 'influxdb' do
     command('eval "$(which influx) -version"').stdout
   end
 
-  it 'should have influxdb version 0.10.3' do
-    expect(influxdb_verion).to match(/0.10.3/)
+  it 'should have influxdb version 1.0.0' do
+    expect(influxdb_verion).to match(/1.0.0/)
   end
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -3,19 +3,18 @@ build:
   steps:
     - install-packages:
         packages: wget
-    - poppen/chefdk:
-        version: 0.10.0
+    - bdangit/chefdk:
+        version: 0.18.26
     - script:
         name: lint style spec
         code: |
-          chef gem install rubocop --version 0.37.0
           chef exec "rake test:quick"
 deploy:
   steps:
     - install-packages:
         packages: wget curl
-    - poppen/chefdk:
-        version: 0.10.0
+    - bdangit/chefdk:
+        version: 0.18.26
     - script:
         name: get version from rake
         code: |


### PR DESCRIPTION
* [major] Support for 1.0.x which is **not backward compatible**
* [major] Updated apt cookbook pin to ~> 4.0
* [major] Updated yum cookbook pin to ~> 4.0
* [minor] Reduce number of TK Cases to 12.1, 12.7 and 12.14.
* [patch] removed specific branch used for `compat_resource`