### PR TITLE
Changed cookbook version pinning for apt and yum

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Ben Dang'
 maintainer_email 'me@bdang.it'
 license          'MIT'
 description      'InfluxDB, a timeseries database'
-version          '5.0.0'
+version          '5.0.1'
 
 # For CLI client
 # https://github.com/redguide/nodejs
@@ -16,8 +16,8 @@ depends 'nodejs', '~> 2.4'
 depends 'chef_handler'
 
 # For apt and yum repositories
-depends 'apt', '~> 4.0'
-depends 'yum', '~> 4.0'
+depends 'apt', '>= 3.0'
+depends 'yum', '>= 3.0'
 
 # For compatibility with 12.X versions of Chef
 depends 'compat_resource'


### PR DESCRIPTION
HI @bdangit,

I have changed the version pinning for the apt and yum cookbook to decrease the conflicts with other cookbooks. In my special case I can't use this cookbook because another cookbook has ```apt ~> 3.0``` as its dependence.

As far as I can see this cookbook would also work perfect with ```apt >= 3.0``` and ```yum >= 3.0```.

Best regards,
Dennis