### PR TITLE
handle InfluxDB::Error when auth enabled without admin user

### DIFF
--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -23,12 +23,10 @@ action :create do
     # Exception due to missing admin user
     # https://influxdb.com/docs/v0.9/administration/authentication.html
     # https://github.com/chrisduong/chef-influxdb/commit/fe730374b4164e872cbf208c06d2462c8a056a6a
-    if e.to_s.include? 'create admin user'
-      client.create_cluster_admin(username, password)
-      updated_by_last_action true
-    else
-      raise e
-    end
+    raise e unless e.to_s.include? 'create admin user'
+
+    client.create_cluster_admin(username, password)
+    updated_by_last_action true
   end
 end
 

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -19,13 +19,15 @@ action :create do
       client.create_cluster_admin(username, password)
       updated_by_last_action true
     end
-  rescue InfluxDB::AuthenticationError => e
+  rescue InfluxDB::Error => e
     # Exception due to missing admin user
     # https://influxdb.com/docs/v0.9/administration/authentication.html
     # https://github.com/chrisduong/chef-influxdb/commit/fe730374b4164e872cbf208c06d2462c8a056a6a
     if e.to_s.include? 'create admin user'
       client.create_cluster_admin(username, password)
       updated_by_last_action true
+    else
+      raise e
     end
   end
 end


### PR DESCRIPTION
The admin resource will fail if auth is enabled and the initial admin user isn't created yet, even though a rescue block is in place to handle that.

The error that influxd returns is '403 Forbidden'.  The influxdb-ruby client raises an InfluxDB::AuthenticationError only when the response is '401 Unauthorized'.  A 403 gets a standard InfluxDB::Error, which slips by the rescue block.  See https://github.com/influxdata/influxdb-ruby/blob/v0.3.10/lib/influxdb/client/http.rb#L32-L35.

It's arguably a bug in influxdb-ruby, but the admin resource is already inspecting the body to identify the actual error so this should work for either error class.