### PR TITLE
Pass force options to package install to enable upgrades

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -46,6 +46,7 @@ action :install do
 
     package 'influxdb' do
       version node['influxdb']['version']
+      options '--force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"' if node.platform_family? 'debian'
     end
   when 'file'
     if node.platform_family? 'rhel'
@@ -71,6 +72,7 @@ action :install do
 
       dpkg_package 'influxdb' do
         source "#{Chef::Config[:file_cache_path]}/#{file_name}"
+        options '--force-confdef --force-confold'
         action :install
       end
     else


### PR DESCRIPTION
Add force options to the debian package installation so the package can be cleanly upgraded. This is needed because we modify `/etc/influxdb/influxdb.conf` and the package wants to own the config file. Tested on Ubunty 14.04 + package installation method.

Before: 

```
* apt_package[influxdb] action install

             ================================================================================
             Error executing action `install` on resource 'apt_package[influxdb]'
             ================================================================================

             Mixlib::ShellOut::ShellCommandFailed
             ------------------------------------
             Expected process to exit with [0], but received '100'
             ---- Begin output of apt-get -q -y install influxdb=1.0.2-1 ----
             STDOUT: Reading package lists...
             Building dependency tree...
             Reading state information...
             The following packages will be upgraded:
        influxdb
             1 upgraded, 0 newly installed, 0 to remove and 9 not upgraded.
             Need to get 17.8 MB of archives.
             After this operation, 34.8 kB of additional disk space will be used.
             Fetched 17.8 MB in 10s (1754 kB/s)
             (Reading database ... 30746 files and directories currently installed.)
             Preparing to unpack .../influxdb_1.0.2-1_amd64.deb ...
             Unpacking influxdb (1.0.2-1) over (1.0.0-1) ...
             Setting up influxdb (1.0.2-1) ...
             STDERR: Configuration file '/etc/influxdb/influxdb.conf'
       ==> Modified (by you or by a script) since installation.
       ==> Package distributor has shipped an updated version.
         What would you like to do about it ?  Your options are:
          Y or I  : install the package maintainer's version
          N or O  : keep your currently-installed version
            D     : show the differences between the versions
            Z     : start a shell to examine the situation
       The default action is to keep your current version.
             *** influxdb.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package influxdb (--configure):
       EOF on stdin at conffile prompt
             Errors were encountered while processing:
       influxdb
             E: Sub-process /usr/bin/dpkg returned an error code (1)
             ---- End output of apt-get -q -y install influxdb=1.0.2-1 ----
             Ran apt-get -q -y install influxdb=1.0.2-1 returned 100
```

After: 

```
 * apt_package[influxdb] action install
             - install version 1.0.2-1 of package influxdb
```