### PR TITLE
adding ssl support for api-based chef resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,12 @@
 Metrics/LineLength:
   Enabled: false
 
+Metrics/MethodLength:
+  Max: 12
+
+Metrics/AbcSize:
+  Max: 16
+
 Style/SpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,6 @@
 Metrics/LineLength:
   Enabled: false
 
-Metrics/MethodLength:
-  Max: 12
-
 Style/SpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # CHANGELOG
 
+## 5.x
+* [patch] Add SSL support for API-based resources
+  (contributed by @kjschnei001)
+
 ## 5.0.3
-* [patch] Pass force options to package install to enable upgrades 
+* [patch] Pass force options to package install to enable upgrades
   (contributed by @eheydrick)
 * [patch] install InfluxDB 1.0.2 (contributed by @eheydrick)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
-## 5.1.1
-* [patch] Add SSL support for API-based resources
+## 5.2.0
+* [minor] Add SSL support for API-based resources
   (contributed by @kjschnei001)
 
 ## 5.1.0

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Ben Dang'
 maintainer_email 'me@bdang.it'
 license          'MIT'
 description      'InfluxDB, a timeseries database'
-version          '5.1.1'
+version          '5.2.0'
 
 # For CLI client
 # https://github.com/redguide/nodejs

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -6,6 +6,10 @@ property :username, String, name_property: true
 property :password, String
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
+property :api_hostname, String, default: 'localhost'
+property :api_port, Integer, default: 8086
+property :use_ssl, [TrueClass, FalseClass], default: false
+property :verify_ssl, [TrueClass, FalseClass], default: false
 
 default_action :create
 
@@ -52,6 +56,10 @@ def client
     InfluxDB::Client.new(
       username: auth_username,
       password: auth_password,
-      retry: 10
+      retry: 10,
+      host: api_hostname,
+      port: api_port,
+      use_ssl: use_ssl,
+      verify_ssl: verify_ssl
     )
 end

--- a/resources/admin.rb
+++ b/resources/admin.rb
@@ -50,6 +50,7 @@ action :delete do
   end
 end
 
+# rubocop:disable Metrics/MethodLength
 def client
   require 'influxdb'
   @client ||=
@@ -63,3 +64,4 @@ def client
       verify_ssl: verify_ssl
     )
 end
+# rubocop:enable Metrics/MethodLength

--- a/resources/continuous_query.rb
+++ b/resources/continuous_query.rb
@@ -51,6 +51,7 @@ def current_cq
 end
 # rubocop:enable Metrics/AbcSize
 
+# rubocop:disable Metrics/MethodLength
 def client
   require 'influxdb'
   @client ||=
@@ -64,3 +65,4 @@ def client
       verify_ssl: verify_ssl
     )
 end
+# rubocop:enable Metrics/MethodLength

--- a/resources/continuous_query.rb
+++ b/resources/continuous_query.rb
@@ -10,6 +10,10 @@ property :resample_every, [String, NilClass], default: nil
 property :resample_for, [String, NilClass], default: nil
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
+property :api_hostname, String, default: 'localhost'
+property :api_port, Integer, default: 8086
+property :use_ssl, [TrueClass, FalseClass], default: false
+property :verify_ssl, [TrueClass, FalseClass], default: false
 
 default_action :create
 
@@ -51,6 +55,10 @@ def client
     InfluxDB::Client.new(
       username: auth_username,
       password: auth_password,
-      retry: 10
+      retry: 10,
+      host: api_hostname,
+      port: api_port,
+      use_ssl: use_ssl,
+      verify_ssl: verify_ssl
     )
 end

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -5,6 +5,10 @@
 property :name, String, name_property: true
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
+property :api_hostname, String, default: 'localhost'
+property :api_port, Integer, default: 8086
+property :use_ssl, [TrueClass, FalseClass], default: false
+property :verify_ssl, [TrueClass, FalseClass], default: false
 
 default_action :create
 
@@ -26,6 +30,10 @@ def client
     InfluxDB::Client.new(
       username: auth_username,
       password: auth_password,
-      retry: 10
+      retry: 10,
+      host: api_hostname,
+      port: api_port,
+      use_ssl: use_ssl,
+      verify_ssl: verify_ssl
     )
 end

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -24,6 +24,7 @@ action :delete do
   updated_by_last_action true
 end
 
+# rubocop:disable Metrics/MethodLength
 def client
   require 'influxdb'
   @client ||=
@@ -37,3 +38,4 @@ def client
       verify_ssl: verify_ssl
     )
 end
+# rubocop:enable Metrics/MethodLength

--- a/resources/retention_policy.rb
+++ b/resources/retention_policy.rb
@@ -48,6 +48,7 @@ def current_policy
   )
 end
 
+# rubocop:disable Metrics/MethodLength
 def client
   require 'influxdb'
   @client ||=
@@ -61,3 +62,4 @@ def client
       verify_ssl: verify_ssl
     )
 end
+# rubocop:enable Metrics/MethodLength

--- a/resources/retention_policy.rb
+++ b/resources/retention_policy.rb
@@ -10,6 +10,10 @@ property :replication, Fixnum, default: 1
 property :default, [TrueClass, FalseClass], default: false
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
+property :api_hostname, String, default: 'localhost'
+property :api_port, Integer, default: 8086
+property :use_ssl, [TrueClass, FalseClass], default: false
+property :verify_ssl, [TrueClass, FalseClass], default: false
 
 default_action :create
 
@@ -50,6 +54,10 @@ def client
     InfluxDB::Client.new(
       username: auth_username,
       password: auth_password,
-      retry: 10
+      retry: 10,
+      host: api_hostname,
+      port: api_port,
+      use_ssl: use_ssl,
+      verify_ssl: verify_ssl
     )
 end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -8,6 +8,10 @@ property :databases, Array, default: []
 property :permissions, Array, default: []
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
+property :api_hostname, String, default: 'localhost'
+property :api_port, Integer, default: 8086
+property :use_ssl, [TrueClass, FalseClass], default: false
+property :verify_ssl, [TrueClass, FalseClass], default: false
 
 default_action :create
 
@@ -50,6 +54,10 @@ def client
     InfluxDB::Client.new(
       username: auth_username,
       password: auth_password,
-      retry: 10
+      retry: 10,
+      host: api_hostname,
+      port: api_port,
+      use_ssl: use_ssl,
+      verify_ssl: verify_ssl
     )
 end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -48,6 +48,7 @@ action :delete do
   end
 end
 
+# rubocop:disable Metrics/MethodLength
 def client
   require 'influxdb'
   @client ||=
@@ -61,3 +62,4 @@ def client
       verify_ssl: verify_ssl
     )
 end
+# rubocop:enable Metrics/MethodLength

--- a/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
@@ -11,6 +11,10 @@ end
 influxdb_user 'test_user' do
   password 'test_password'
   databases [dbname]
+  api_hostname 'localhost'
+  api_port 8086
+  use_ssl false
+  verify_ssl false
   action :create
 end
 


### PR DESCRIPTION
The build appears to be broken due to https://github.com/bdangit/chef-influxdb/issues/133:
`STDERR: E: Version '1.0.2-1' for 'influxdb' was not found`

However, I spot tested on other platforms with success:
```
-----> serverspec installed (version 2.37.2)
       /opt/chef/embedded/bin/ruby -I/tmp/verifier/suites/serverspec -I/tmp/verifier/gems/gems/rspec-support-3.5.0/lib:/tmp/verifier/gems/gems/rspec-core-3.5.4/lib /opt/chef/embedded/bin/rspec --pattern /tmp/verifier/suites/serverspec/\*\*/\*_spec.rb --color --format documentation --default-path /tmp/verifier/suites/serverspec
       
       influxdb
         User "influxdb"
           should exist
         Service "influxdb"
           should be running
         Port "8083"
           should be listening
         Port "8086"
           should be listening
         test_database
           exists
           default retention policy
             exists
             is set for 1 week
             is set for 1 replica
             is the default
           test continuous queries
             is exists
         test_user
           exists
           is not an admin
         test_admin
           exists
           is an admin
       
       Finished in 0.17257 seconds (files took 0.32621 seconds to load)
       14 examples, 0 failures
       
       Finished verifying <default-centos-72-chef1214> (0m26.89s).
```