### PR TITLE
Use `Generator` class instead of `dump` method for config generation

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -11,7 +11,7 @@ action :create do
   require 'toml'
 
   file path do
-    content TOML.dump(config)
+    content TOML::Generator.new(config).body
   end
 end
 


### PR DESCRIPTION
Use `Generator` class instead of `dump` method for config generation.

```
[2017-04-11T05:52:05+00:00] ERROR: influxdb_config[/etc/influxdb/influxdb.conf] (influxdb::default line 20) had an error: NoMethodError: undefined method `dump' for TOML:Module
```