### PR TITLE
Fix install of influxdb

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,17 +7,15 @@ provisioner:
   name: chef_zero
 
 platforms:
-<% %w(12.14 12.7 12.1).each do |chef_version| %>
+<% %w(13.0 12.19).each do |chef_version| %>
   - name: ubuntu-14.04-chef<%= chef_version %>
     driver_config:
       image: ubuntu:14.04
       platform: ubuntu
       require_chef_omnibus: <%= chef_version %>
-      provision_command:
-          - apt-get install net-tools -y
-  - name: ubuntu-15.10-chef<%= chef_version %>
+  - name: ubuntu-16.10-chef<%= chef_version %>
     driver_config:
-      box: ubuntu:15.10
+      box: ubuntu:16.10
       platform: ubuntu
       run_command: /sbin/init
       privileged: true
@@ -25,29 +23,23 @@ platforms:
         - apt-get install net-tools -y
     provisioner:
       require_chef_omnibus: <%= chef_version %>
-  - name: debian-8.5-chef<%= chef_version %>
+  - name: debian-8.7-chef<%= chef_version %>
     driver_config:
-      box: debian:8.5
+      box: debian:8.7
       platform: debian
       run_command: /sbin/init
       privileged: true
-      provision_command:
-        - apt-get install wget -y
-        - apt-get install net-tools -y
     provisioner:
       require_chef_omnibus: <%= chef_version %>
   - name: centos-6.8-chef<%= chef_version %>
     driver_config:
       box: centos:6.8
       platform: centos
-      provision_command:
-       - yum install net-tools -y
-       - yum install iproute -y
     provisioner:
       require_chef_omnibus: <%= chef_version %>
-  - name: centos-7.2-chef<%= chef_version %>
+  - name: centos-7.3-chef<%= chef_version %>
     driver_config:
-      box: centos:7.2
+      box: centos:7.3
       platform: centos
       run_command: /usr/sbin/init
       privileged: true
@@ -62,7 +54,6 @@ suites:
   - name: default
     run_list:
       - recipe[influxdb-test::default]
-      - recipe[netstat]
     attributes:
   - name: file
     run_list:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
 # CHANGELOG
 
+## 6.0.0
+* [major] Removed support for 12.1 thru 12.4.
+* [minor] Fix install of influxdb
+    - `node['influxdb']['include_repository']` was getting set to `nil` even
+    though custom resource `influxdb_install` set `include_repository`
+    default to false.  To fix needed to set the node attribute to be set
+    properly
+    - fixed rubocop styling
+    - fixed foodcritic lints
+    - updated kitchen to test for Chef 13
+    - updated wercker profile to use latest and greatest chefdk
+* [patch] Use `Generator` class instead of `dump` method for config generation [#143](../../pull/143) (contributed by @ton31337)
+    - *We are no longer using `toml-rb` and instead use `toml`*
+
 ## 5.2.2
-* [patch] notifying influxes service after config change [#140](../../pull/140) 
+* [patch] notifying influxes service after config change [#140](../../pull/140)
   (contributed by @nilroy)
 
 ## 5.2.1

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ group :integration do
 end
 
 group :test do
-  gem 'minitest'
-  gem 'rubocop'
-  gem 'rake'
   gem 'foodcritic'
+  gem 'minitest'
+  gem 'rake'
+  gem 'rubocop'
 end

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following gems are used by the custom resources and are installed by the
 `default` recipe:
 
  - [InfluxDB gem](https://github.com/influxdb/influxdb-ruby)
- - [toml-rb](https://github.com/emancu/toml-rb)
+ - [toml](https://github.com/jm/toml)
 
 This cookbook ships with five custom resources for managing the configuration
 file, users, databases, cluster admins, and retention policies:
@@ -117,7 +117,7 @@ end
 ### influxdb\_continuous\_query
 This resources configures a continuous query on a given database.
 
-> If you need rewrite continuous query if it already exist set `rewrite` parametr to `true`. 
+> If you need rewrite continuous query if it already exist set `rewrite` parametr to `true`.
 
 ```ruby
 influxdb_continuous_query "test_continuous_query" do

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'foodcritic'
 
 task default: 'test:quick'
 
+# rubocop:disable Metrics/BlockLength
 namespace :test do
   RuboCop::RakeTask.new
 
@@ -51,6 +52,7 @@ namespace :test do
     Rake::Task['test:integration:vagrant'].invoke
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 desc 'Print version of cookbook'
 task :version do

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,7 @@
 
 default['influxdb']['version'] = nil
 default['influxdb']['install_type'] = 'package'
+default['influxdb']['include_repository'] = true
 
 default['influxdb']['download_urls'] = {
   'debian' => 'https://dl.influxdata.com/influxdb/releases',

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,23 +5,21 @@ maintainer       'Ben Dang'
 maintainer_email 'me@bdang.it'
 license          'MIT'
 description      'InfluxDB, a timeseries database'
-version          '5.2.2'
+version          '6.0.0'
+
+supports 'centos'
+supports 'debian'
+supports 'redhat'
+supports 'ubuntu'
 
 # For CLI client
 # https://github.com/redguide/nodejs
-depends 'nodejs', '~> 2.4'
+depends 'nodejs', '>= 2.4.4'
 
 # For ChefInfluxDB Chef handler
 # https://github.com/jakedavis/chef-handler-influxdb
 depends 'chef_handler'
 
-# For apt and yum repositories
-depends 'apt', '>= 3.0'
-depends 'yum', '>= 3.0'
-
-# For compatibility with 12.X versions of Chef
-depends 'compat_resource'
-
-chef_version '>= 12.0' if respond_to?(:chef_version)
+chef_version '>= 12.5' if respond_to?(:chef_version)
 source_url 'https://github.com/bdangit/chef-influxdb' if respond_to?(:source_url)
 issues_url 'https://github.com/bdangit/chef-influxdb/issues' if respond_to?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 
 # Installs InfluxDB
 
-chef_gem 'toml-rb' do
+chef_gem 'toml' do
   compile_time false if respond_to?(:compile_time)
 end
 

--- a/resources/continuous_query.rb
+++ b/resources/continuous_query.rb
@@ -39,7 +39,7 @@ end
 
 # rubocop:disable Metrics/AbcSize
 def current_cq
-  @current_cq ||= (
+  @current_cq ||= begin
     current_cq_arr = client.list_continuous_queries(database).select do |c|
       c['name'] == name
     end
@@ -47,7 +47,7 @@ def current_cq
       Chef::Log.fatal("Unexpected number of matches for continuous query #{name} on database #{database}: #{current_policy_arr}")
     end
     current_cq_arr[0] if current_cq_arr.length
-  )
+  end
 end
 # rubocop:enable Metrics/AbcSize
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -11,6 +11,7 @@ default_action :install
 
 include InfluxdbCookbook::Helpers
 
+# rubocop:disable Metrics/BlockLength
 action :install do
   case install_type
   when 'package'
@@ -82,6 +83,7 @@ action :install do
     raise "#{install_type} is not a valid install type."
   end
 end
+# rubocop:enable Metrics/BlockLength
 
 action :remove do
   if node.platform_family? 'rhel'

--- a/resources/retention_policy.rb
+++ b/resources/retention_policy.rb
@@ -6,7 +6,7 @@ property :name, String, name_property: true
 property :policy_name, String
 property :database, String
 property :duration, String, default: 'INF'
-property :replication, Fixnum, default: 1
+property :replication, Integer, default: 1
 property :default, [TrueClass, FalseClass], default: false
 property :auth_username, String, default: 'root'
 property :auth_password, String, default: 'root'
@@ -37,7 +37,7 @@ action :delete do
 end
 
 def current_policy
-  @current_policy ||= (
+  @current_policy ||= begin
     current_policy_arr = client.list_retention_policies(database).select do |p|
       p['name'] == policy_name
     end
@@ -45,7 +45,7 @@ def current_policy
       Chef::Log.fatal("Unexpected number of matches for retention policy #{policy_name} on database #{database}: #{current_policy_arr}")
     end
     current_policy_arr[0] if current_policy_arr.length
-  )
+  end
 end
 
 # rubocop:disable Metrics/MethodLength

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 describe 'influxdb' do
   describe user('influxdb') do
     it { is_expected.to exist }
@@ -83,3 +84,4 @@ describe 'influxdb' do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/wercker.yml
+++ b/wercker.yml
@@ -4,7 +4,7 @@ build:
     - install-packages:
         packages: wget
     - bdangit/chefdk:
-        version: 0.18.26
+        version: 1.3.43
     - script:
         name: lint style spec
         code: |
@@ -14,7 +14,7 @@ deploy:
     - install-packages:
         packages: wget curl
     - bdangit/chefdk:
-        version: 0.18.26
+        version: 1.3.43
     - script:
         name: get version from rake
         code: |


### PR DESCRIPTION
This PR should address issue with #144 and clean up support for Chef 13.

- `node['influxdb']['include_repository']` was getting set to `nil` even
though custom resource `influxdb_install` set `include_repository`
default to false.  To fix needed to set the node attribute to be set
properly
- fixed rubocop styling
- fixed foodcritic lints
- updated kitchen to test for Chef 13
- updated wercker profile to use latest and greatest chefdk

Signed-off-by: Ben Dang <me@bdang.it>