### PR TITLE
Update to support latest toml-rb 1.0.0 gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [unreleased]
 
+## 4.4.2
+* Updated for compliance with toml-rb 1.0.0 gem
+
 ## 4.4.1
 * Add steps to cut release
 * Fix invalid property type 'nil' in continuous query options (contributed by @kentarosasaki)

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Ben Dang'
 maintainer_email 'me@bdang.it'
 license          'MIT'
 description      'InfluxDB, a timeseries database'
-version          '4.4.1'
+version          '4.4.2'
 
 # For CLI client
 # https://github.com/redguide/nodejs

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -8,10 +8,10 @@ property :config, Hash, required: true
 default_action :create
 
 action :create do
-  require 'toml'
+  require 'toml-rb'
 
   file path do
-    content TOML.dump(config)
+    content TomlRB.dump(config)
   end
 end
 


### PR DESCRIPTION
Unfortunatelly there is no branch for 4.4.1 version so creating request to master. 

Could you please create an "old stable" branch to use with older influxdb versions?