### PR TITLE
ability to install InfluxDB Enterprise packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ influxdb_install 'influxdb' do
 end
 ```
 
+> Note : InfluxDB Enterprise uses different version naming schema and is 
+> distributed in two packages: `influxdb-data` and `influxdb-meta`.
+> Install it this way:
+
+```ruby
+node.default['influxdb']['version'] = "1.3.5-c1.3.5"
+node.default['influxdb']['download_urls'] = {
+  'debian' => 'https://dl.influxdata.com/enterprise/releases',
+  'rhel' => 'https://dl.influxdata.com/enterprise/releases'
+}
+
+influxdb_install 'influxdb-meta' do
+  install_version node['influxdb']['version']
+  install_type 'file'
+  checksum '87d99ba4a90487ee1a9'
+  action [:install]
+end
+
+influxdb_install 'influxdb-data' do
+  install_version node['influxdb']['version']
+  install_type 'file'
+  checksum '4c17e7d3bac8f565c140'
+  action [:install]
+end
+```
+
 ### influxdb\_user
 This resources configures a user to interact with InfluxDB databases.
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -8,7 +8,7 @@ property :influxdb_key, kind_of: String, default: 'https://repos.influxdata.com/
 property :install_version, [String, nil], default: nil
 property :install_type, String, default: 'package'
 property :package_name, String, name_property: true
-property :checksum, String, default: node['influxdb']['shasums'][node[:platform_family]]
+property :checksum, String, default: node['influxdb']['shasums'][node['platform_family']]
 default_action :install
 
 include InfluxdbCookbook::Helpers

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -7,6 +7,8 @@ property :include_repository, kind_of: [TrueClass, FalseClass], default: true
 property :influxdb_key, kind_of: String, default: 'https://repos.influxdata.com/influxdb.key'
 property :install_version, [String, nil], default: nil
 property :install_type, String, default: 'package'
+property :package_name, String, name_property: true
+property :checksum, String, default: node['influxdb']['shasums'][node[:platform_family]]
 default_action :install
 
 include InfluxdbCookbook::Helpers
@@ -51,27 +53,27 @@ action :install do
     end
   when 'file'
     if node.platform_family? 'rhel'
-      file_name = "influxdb-#{install_version}.x86_64.rpm"
+      file_name = "#{package_name}-#{install_version}.x86_64.rpm"
       remote_file "#{Chef::Config[:file_cache_path]}/#{file_name}" do
         source "#{node['influxdb']['download_urls']['rhel']}/#{file_name}"
-        checksum node['influxdb']['shasums']['rhel']
+        checksum checksum
         action :create
       end
 
-      rpm_package 'influxdb' do
+      rpm_package package_name do
         source "#{Chef::Config[:file_cache_path]}/#{file_name}"
         action :install
       end
     elsif node.platform_family? 'debian'
       # NOTE: file_name would be influxdb_<version> instead.
-      file_name = "influxdb_#{install_version}_amd64.deb"
+      file_name = "#{package_name}_#{install_version}_amd64.deb"
       remote_file "#{Chef::Config[:file_cache_path]}/#{file_name}" do
         source "#{node['influxdb']['download_urls']['debian']}/#{file_name}"
-        checksum node['influxdb']['shasums']['debian']
+        checksum checksum
         action :create
       end
 
-      dpkg_package 'influxdb' do
+      dpkg_package package_name do
         source "#{Chef::Config[:file_cache_path]}/#{file_name}"
         options '--force-confdef --force-confold'
         action :install
@@ -100,7 +102,7 @@ action :remove do
     raise "I do not support your platform: #{node['platform_family']}"
   end
 
-  package 'influxdb' do
+  package package_name do
     action :remove
   end
 end


### PR DESCRIPTION
InfluxDB Enterprise is distributed in two packages 'influxdb-meta' and 'influxdb-data'.
Would be great to use the same community cookbook to install cluster.

influxdb_install resource has been extended a little to be able to override default 'influxdb' package name and a checksum.
