### PR TITLE
add support to configure shard_duration to retention_policy resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 Metrics/LineLength:
   Enabled: false
 
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ namespace :test do
   FoodCritic::Rake::LintTask.new do |t|
     t.name = :foodcritic
     t.options = {
-      tags: ['~FC016'],
+      tags: ['~FC016', '~FC121'],
       fail_tags: ['any']
     }
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer       'Ben Dang'
 maintainer_email 'me@bdang.it'
 license          'MIT'
 description      'InfluxDB, a timeseries database'
-version          '6.2.0'
+version          '6.3.0'
 
 supports 'centos'
 supports 'debian'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -4,10 +4,10 @@
 
 %w[cli ruby].each do |flavor|
   next unless begin
-                 node['influxdb']['client'][flavor]['enable']
-               rescue
-                 nil
-               end
+                node['influxdb']['client'][flavor]['enable']
+              rescue Error
+                nil
+              end
 
   include_recipe "influxdb::#{flavor}_client"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,7 @@ chef_gem 'toml' do
 end
 
 chef_gem 'influxdb' do
+  version '0.6.1'
   compile_time false if respond_to?(:compile_time)
 end
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -2,16 +2,18 @@
 
 # Resource for InfluxDB install
 
-property :arch_type, kind_of: String
-property :include_repository, kind_of: [TrueClass, FalseClass], default: true
-property :influxdb_key, kind_of: String, default: 'https://repos.influxdata.com/influxdb.key'
+property :arch_type, String
+property :include_repository, [TrueClass, FalseClass], default: true
+property :influxdb_key, String, default: 'https://repos.influxdata.com/influxdb.key'
 property :install_version, [String, nil], default: nil
 property :install_type, String, default: 'package'
 property :package_name, String, name_property: true
 property :checksum, String, default: node['influxdb']['shasums'][node['platform_family']]
 default_action :install
 
+# rubocop:disable Style/MixinUsage
 include InfluxdbCookbook::Helpers
+# rubocop:enable Style/MixinUsage
 
 # rubocop:disable Metrics/BlockLength
 action :install do

--- a/resources/retention_policy.rb
+++ b/resources/retention_policy.rb
@@ -5,6 +5,7 @@
 property :policy_name, String
 property :database, String
 property :duration, String, default: 'INF'
+property :shard_duration, String, default: '7d'
 property :replication, Integer, default: 1
 property :default, [TrueClass, FalseClass], default: false
 property :auth_username, String, default: 'root'
@@ -19,11 +20,15 @@ default_action :create
 
 action :create do
   if current_policy
-    if current_policy['duration'] != new_resource.duration || current_policy['replicaN'] != new_resource.replication || current_policy['default'] != new_resource.default
-      client.alter_retention_policy(new_resource.policy_name, new_resource.database, new_resource.duration, new_resource.replication, new_resource.default)
+    if current_policy['duration'] != new_resource.duration || current_policy['replicaN'] != new_resource.replication || current_policy['default'] != new_resource.default || current_policy['shard_duration'] != new_resource.shard_duration
+      converge_by 'updated retention policy' do
+        client.alter_retention_policy(new_resource.policy_name, new_resource.database, new_resource.duration, new_resource.replication, new_resource.default, shard_duration: new_resource.shard_duration)
+      end
     end
   else
-    client.create_retention_policy(new_resource.policy_name, new_resource.database, new_resource.duration, new_resource.replication, new_resource.default)
+    converge_by 'created retention policy' do
+      client.create_retention_policy(new_resource.policy_name, new_resource.database, new_resource.duration, new_resource.replication, new_resource.default, shard_duration: new_resource.shard_duration)
+    end
   end
 end
 

--- a/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/influxdb-test/recipes/default.rb
@@ -29,6 +29,7 @@ influxdb_retention_policy 'test_policy' do
   policy_name 'default'
   database dbname
   duration '1w'
+  shard_duration '24h'
   replication 1
   # by default in v1.0 there's a policy named autogen that is created for any
   # db, when `meta.retention-autocreate`=true. We will make this test_policy

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -36,8 +36,12 @@ describe 'influxdb' do
         expect(retention_policies).to match(/default/)
       end
 
-      it 'is set for 1 week' do
-        expect(retention_policies).to match(/default.*168h0m0s/)
+      it 'its retention is set for 1 week' do
+        expect(retention_policies).to match(/default\s+168h0m0s/)
+      end
+
+      it 'its shard duration is set for 24 hours' do
+        expect(retention_policies).to match(/default\s+.*\s+24h0m0s/)
       end
 
       it 'is set for 1 replica' do


### PR DESCRIPTION
I ran the integration tests across 2 different versions of chef and the changes work.  I don't think the cookbook in general is written to support chef v14 as I found issues unrelated to things I changed:

Chef 12
```
       influxdb
         User "influxdb"
           should exist
         Service "influxdb"
           should be running
         Port "8086"
           should be listening
         test_database
           exists
           default retention policy
             exists
             its retention is set for 1 week
             its shard duration is set for 24 hours
             is set for 1 replica
             is the default
           test continuous queries
             is exists
         test_user
           exists
           is not an admin
         test_admin
           exists
           is an admin
       
       Finished in 0.20375 seconds (files took 0.31744 seconds to load)
       14 examples, 0 failures
       
       Finished verifying <default-centos-73-chef1219> (0m5.72s).
```

Chef 13
```
       influxdb
         User "influxdb"
           should exist
         Service "influxdb"
           should be running
         Port "8086"
           should be listening
         test_database
           exists
           default retention policy
             exists
             its retention is set for 1 week
             its shard duration is set for 24 hours
             is set for 1 replica
             is the default
           test continuous queries
             is exists
         test_user
           exists
           is not an admin
         test_admin
           exists
           is an admin
       
       Finished in 0.21215 seconds (files took 0.30468 seconds to load)
       14 examples, 0 failures
       
       Finished verifying <default-centos-73-chef139> (0m6.37s).
```

Chef 14
```
           NoMethodError
           -------------
           undefined method `updated_by_last_action' for #<#<Class:0x0000000003ea5ff8>:0x0000000003983250>
           
           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/influxdb/resources/retention_policy.rb:29:in `block in class_from_file'

```