### PR TITLE
[Continuous query] Fix attribute naming

### DIFF
--- a/resources/continuous_query.rb
+++ b/resources/continuous_query.rb
@@ -20,11 +20,11 @@ default_action :create
 action :create do
   if current_cq
     if new_resource.rewrite
-      client.delete_continuous_query(name, database)
-      client.create_continuous_query(name, database, query, resample_every: resample_every, resample_for: resample_for)
-      updated_by_last_action true
+      client.delete_continuous_query(new_resource.name, new_resource.database)
+      client.create_continuous_query(new_resource.name, new_resource.database, new_resource.query, resample_every: new_resource.resample_every, resample_for: new_resource.resample_for)
+      new_resource.updated_by_last_action true
     else
-      Chef::Log.info("The continuous query #{name} on #{database} already exists. Skip this step.")
+      Chef::Log.info("The continuous query #{new_resource.name} on #{new_resource.database} already exists. Skip this step.")
     end
   else
     client.create_continuous_query(new_resource.name, new_resource.database, new_resource.query, resample_every: new_resource.resample_every, resample_for: new_resource.resample_for)
@@ -41,9 +41,7 @@ def current_cq
     current_cq_arr = client.list_continuous_queries(database).select do |c|
       c['name'] == name
     end
-    if current_cq_arr.length > 1
-      Chef::Log.fatal("Unexpected number of matches for continuous query #{name} on database #{database}: #{current_policy_arr}")
-    end
+    current_cq_arr.length > 1 && Chef::Log.fatal("Unexpected number of matches for continuous query #{name} on database #{database}: #{current_policy_arr}")
     current_cq_arr[0] if current_cq_arr.length
   end
 end


### PR DESCRIPTION
Under at least Chef 14, cookbook run fails when updating a CQ resource : 

```
NameError
    ---------
    undefined local variable or method `name' for #<#<Class:0x0000000003f915e8>:0x0000000003f53450>
    
    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/influxdb/resources/continuous_query.rb:27:in `block in class_from_file'
```

By explicitely using `new_resource` variable, error is fixed.